### PR TITLE
Migrated with `dart migrate` to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+- Mirgrated to null safety
+
 ## 1.1.0
 
 - Added extensions.

--- a/lib/src/extensions/string_extensions.dart
+++ b/lib/src/extensions/string_extensions.dart
@@ -24,5 +24,5 @@ extension StringExtensions on String {
   ///
   /// ##### Returns
   /// (BestMatch): An object with a ratings property, which gives a similarity rating for each target string, a bestMatch property, which specifies which target string was most similar to the main string, and a bestMatchIndex property, which specifies the index of the bestMatch in the targetStrings array.
-  BestMatch bestMatch(List<String> targetStrings) => StringSimilarity.findBestMatch(this, targetStrings);
+  BestMatch bestMatch(List<String?> targetStrings) => StringSimilarity.findBestMatch(this, targetStrings);
 }

--- a/lib/src/models/best_match.dart
+++ b/lib/src/models/best_match.dart
@@ -5,13 +5,13 @@ class BestMatch {
   BestMatch({this.ratings, this.bestMatch, this.bestMatchIndex});
 
   /// similarity rating for each target string
-  List<Rating> ratings;
+  List<Rating>? ratings;
 
   /// specifies which target string was most similar to the main string
-  Rating bestMatch;
+  Rating? bestMatch;
 
   /// which specifies the index of the bestMatch in the targetStrings array
-  int bestMatchIndex;
+  int? bestMatchIndex;
 
   @override
   String toString() => '$bestMatchIndex:${bestMatch.toString()}';

--- a/lib/src/models/rating.dart
+++ b/lib/src/models/rating.dart
@@ -3,9 +3,9 @@ class Rating {
   Rating({this.target, this.rating});
 
   /// reference text
-  String target;
+  String? target;
   /// between 0 and 1. 0 indicates completely different strings, 1 indicates identical strings.
-  double rating;
+  double? rating;
 
   @override
   String toString() => '\'$target\'[$rating]';

--- a/lib/src/string_similarity_base.dart
+++ b/lib/src/string_similarity_base.dart
@@ -43,14 +43,14 @@ class StringSimilarity {
     final firstBigrams = <String, int>{};
     for (var i = 0; i < first.length - 1; i++) {
       final bigram = first.substring(i, i + 2);
-      final count = firstBigrams.containsKey(bigram) ? firstBigrams[bigram] + 1 : 1;
+      final count = firstBigrams.containsKey(bigram) ? firstBigrams[bigram]! + 1 : 1;
       firstBigrams[bigram] = count;
     }
 
     var intersectionSize = 0;
     for (var i = 0; i < second.length - 1; i++) {
       final bigram = second.substring(i, i + 2);
-      final count = firstBigrams.containsKey(bigram) ? firstBigrams[bigram] : 0;
+      final count = firstBigrams.containsKey(bigram) ? firstBigrams[bigram]! : 0;
 
       if (count > 0) {
         firstBigrams[bigram] = count - 1;
@@ -71,15 +71,15 @@ class StringSimilarity {
   ///
   /// ##### Returns
   /// (BestMatch): An object with a ratings property, which gives a similarity rating for each target string, a bestMatch property, which specifies which target string was most similar to the main string, and a bestMatchIndex property, which specifies the index of the bestMatch in the targetStrings array.
-  static BestMatch findBestMatch(String mainString, List<String> targetStrings) {
+  static BestMatch findBestMatch(String mainString, List<String?> targetStrings) {
     final ratings = <Rating>[];
     var bestMatchIndex = 0;
 
     for (var i = 0; i < targetStrings.length; i++) {
-      final currentTargetString = targetStrings[i];
+      final currentTargetString = targetStrings[i]!;
       final currentRating = compareTwoStrings(mainString, currentTargetString);
       ratings.add(Rating(target: currentTargetString, rating: currentRating));
-      if (currentRating > ratings[bestMatchIndex].rating) {
+      if (currentRating > ratings[bestMatchIndex].rating!) {
         bestMatchIndex = i;
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Jérémy LANDON <contact@jeremylandon.com>
 homepage: https://github.com/Golapadeog/string-similarity
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 #dependencies:
 #  path: ^1.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: string_similarity
 description: Finds degree of similarity between two strings, based on Dice's Coefficient, which is mostly better than Levenshtein distance.
-version: 1.1.0
+version: 2.0.0
 author: Jérémy LANDON <contact@jeremylandon.com>
 homepage: https://github.com/Golapadeog/string-similarity
 

--- a/test/string_similarity_test.dart
+++ b/test/string_similarity_test.dart
@@ -4,13 +4,13 @@ import 'package:test/test.dart';
 class TestData {
   TestData({this.sentenceA, this.sentenceB, this.expected});
 
-  String sentenceA;
-  String sentenceB;
-  double expected;
+  String? sentenceA;
+  String? sentenceB;
+  double? expected;
 }
 
 void main() {
-  List<TestData> _testData;
+  late List<TestData> _testData;
   group('compareTwoStrings', () {
     setUp(() {
       _testData = <TestData>[
@@ -49,14 +49,14 @@ void main() {
 
     test('returns the correct value for different inputs', () {
       for (var td in _testData) {
-        expect(StringSimilarity.compareTwoStrings(td.sentenceA, td.sentenceB), td.expected);
+        expect(StringSimilarity.compareTwoStrings(td.sentenceA!, td.sentenceB!), td.expected);
       }
     });
 
     test('similarityTo extensions method return same result that StringSimilarity.compareTwoStrings', () {
       for (var td in _testData) {
-        final a = StringSimilarity.compareTwoStrings(td.sentenceA, td.sentenceB);
-        final b = td.sentenceA.similarityTo(td.sentenceB);
+        final a = StringSimilarity.compareTwoStrings(td.sentenceA!, td.sentenceB!);
+        final b = td.sentenceA!.similarityTo(td.sentenceB!);
 
         expect(a.toString(), b.toString());
       }
@@ -76,17 +76,17 @@ void main() {
     test('assigns a similarity rating to each string passed in the array', () {
       final matches = StringSimilarity.findBestMatch('healed', _testData.map((TestData testEntry) => testEntry.sentenceA).toList());
 
-      for (var i = 0; i < matches.ratings.length; i++) {
-        expect(_testData[i].sentenceA, matches.ratings[i].target);
-        expect(_testData[i].expected, matches.ratings[i].rating);
+      for (var i = 0; i < matches.ratings!.length; i++) {
+        expect(_testData[i].sentenceA, matches.ratings![i].target);
+        expect(_testData[i].expected, matches.ratings![i].rating);
       }
     });
 
     test('returns the best match and its similarity rating', () {
       final matches = StringSimilarity.findBestMatch('healed', _testData.map((TestData testEntry) => testEntry.sentenceA).toList());
 
-      expect(matches.bestMatch.target, 'sealed');
-      expect(matches.bestMatch.rating, 0.8);
+      expect(matches.bestMatch!.target, 'sealed');
+      expect(matches.bestMatch!.rating, 0.8);
     });
 
     test('returns the index of best match from the target strings', () {


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to `2.12.0+`
* Run `dart migrate` on existing code to remove unsafe nulls
* Add a new version (`2.0.0`) to the changelog (as [recommended](https://dart.dev/null-safety/migration-guide#package-version))

Please check everything twice!

## Testing
- [x] All existing Tests are passing
- [x] Tested manually the example 

### Related tickets
Closes #4 